### PR TITLE
Update Performance Information of P2Pool-vtc

### DIFF
--- a/docs/FullNodes/raspberry-pi.md
+++ b/docs/FullNodes/raspberry-pi.md
@@ -728,8 +728,8 @@ You can do the same by passing parameters to `P2Pool`:
 
 >In my experience you can get as low as 6 total connections (3 in, 3 out) without noticeable efficiency changes. The default values seem overkill (6 outgoing, 40 incoming). The large number of incoming connections (--max-conns) is designed to help the whole network (some nodes are behind firewalls that don't allow incoming connections). You probably should allow more incoming connections (and check that your network setup allows incoming connections) to do your part in helping the network. `[4]`
 
-`PERFORMANCE INFO:` Using the above tunings for `vertcoind` and `p2pool-vtc` reflects a 1.5% DOA rate over 14 hours of hashing with a GTX 1070 with 114% shares efficiency.
-![PoolPerformance](http://i.imgur.com/xOhYXh8.png)
+`PERFORMANCE INFO:` Using the above tunings for `vertcoind` and `p2pool-vtc` reflects a 1.6% DOA rate over 47 hours of hashing with a GTX 1070 with 103% shares efficiency, 17 shares total with 1 orphaned share.
+![PoolPerformance](https://i.imgur.com/Ekxpa0Y.png)
 -----------------------------------------
 
 `p2pool-vtc Documentation: https://github.com/vertcoin-project/p2pool-vtc`


### PR DESCRIPTION
1.) Updated pool performance with a larger time scale of 47 hours. The DOA % rate ended up being .1% off of when I looked at it at 14 hours. There was some fluctuation between 1.2% - 3% the majority of the time with the DOA % peaking at 5% at times. I found the experience to be stable using p2pool-vtc for just Vertcoin mining, I personally think this is a viable option for those who like to tinker.