### PR TITLE
Fix wrong LinkedIn link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,11 +45,11 @@ extra:
       link: 'https://www.reddit.com/r/vertcoin/'
     - type: 'slack'
       link: 'https://slack.vtconline.org/'
-    - type: 'facebook'
-      link: 'https://linkedin.com/in/squidfunk'
+    - type: 'linkedin'
+      link: 'https://www.linkedin.com/company/vertcoincore/'
       
    
-copyright: 'Copyright &copy; 2017 Vertcoin'
+copyright: 'Copyright &copy; 2017-present Vertcoin'
 
 
 markdown_extensions:


### PR DESCRIPTION
ping @b17z 

----

Hi, :smiley:

I fixed the LinkedIn link in `mkdocs.yml`. ✏️ 

--[**Suriyaa Sundararuban**](https://suriyaa.tk/) <a href="https://github.com/SuriyaaKudoIsc"><img src="https://assets-cdn.github.com/images/icons/emoji/octocat.png" alt="GitHub Developer" width="18" height="18" /></a> <a href="https://vertcoin.org/team/"><img src="https://cdn.discordapp.com/emojis/430323443918176256.png" alt="Future Official Vertcoin Developer?" width="20" height="20" /></a> (***Donate some VTC:*** `3GzoCsknkwM7ZSqKYYsUaz7wCMnFbCN6uh`)