### PR TITLE
Correct Discord & VertDocs links

### DIFF
--- a/docs/Contributing/Bounties.md
+++ b/docs/Contributing/Bounties.md
@@ -2,11 +2,11 @@
 
 Bounties are only paid upon completion to standards at the discretion of the 
 development team. Please contact the development team on 
-[Discord](https://discord.gg/SUy9Hsr) prior to starting work. If there are 
+[Discord](https://discord.gg/vertcoin) prior to starting work. If there are 
 multiple bidders, it is possible to collaborate and split the bounty.
 
 VertDocs bounties can be claimed by opening a new pull request on the 
-[VertDocs Github page](https://github.com/Bryangoodson/VertDocs) with at least
+[VertDocs Github page](https://github.com/vertcoin-project/VertDocs) with at least
 one change in it, declaring the section you are working on. From that point you
 will have seven days to provide a final draft for the section before the pull
 request will be closed, and the section will be opened for other submissions.


### PR DESCRIPTION
@b17z 

----

Hi, :smiley:

I corrected the links to Discord & VertDocs' GitHub repo in `docs/Contributing/Bounties.md`. ✏️ 

--[**Suriyaa Sundararuban**](https://suriyaa.tk/) <a href="https://github.com/SuriyaaKudoIsc"><img src="https://assets-cdn.github.com/images/icons/emoji/octocat.png" alt="GitHub Developer" width="18" height="18" /></a> <a href="https://vertcoin.org/team/"><img src="https://cdn.discordapp.com/emojis/430323443918176256.png" alt="Future Official Vertcoin Developer?" width="20" height="20" /></a> (***Donate some VTC:*** `3GzoCsknkwM7ZSqKYYsUaz7wCMnFbCN6uh`)